### PR TITLE
upon an error for the predictions database, return an empty result

### DIFF
--- a/api/controllers/utils/dbutil.js
+++ b/api/controllers/utils/dbutil.js
@@ -867,7 +867,9 @@ exp.getPathwayJSON = function(pathway, req, callback) {
             function(cb) {
                 pathwaydb.get('RNASEQ!PREDICTIONS!' + pathway.database.toUpperCase() + '!' + pathway.id, function(err, data) {
                     if (err) {
-                        handleDBError(err, cb)
+                        //handleDBError(err, cb)
+                        r.genes.predicted = []
+                        cb()
                     } else {
                         r.genes.predicted = getPredictions(data, null, {
                             start: req.query.start,


### PR DESCRIPTION
- upon an error for the predictions database, return an empty result instead (this fixes no results for predictions AND annotations, when only predictions is empty)